### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   # ── Security Scan ─────────────────────────────────────────────────
   security-scan:
@@ -81,6 +84,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-ai-engine, build-grc-engine, build-api-gateway]
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/neocristal/hybridSOC/security/code-scanning/7](https://github.com/neocristal/hybridSOC/security/code-scanning/7)

Add explicit `permissions` to the workflow so `GITHUB_TOKEN` is least-privileged by default, then elevate only where required.

Best fix here (without changing functionality):
- Add a root-level `permissions` block with `contents: read` so all jobs default to read-only repo access.
- Add a job-level `permissions` block for `push-images` with:
  - `contents: read`
  - `packages: write` (required to push to GHCR with `GITHUB_TOKEN`)

This keeps current behavior (build/test/scan/deploy) while explicitly restricting token capabilities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
