### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/neocristal/hybridSOC/security/code-scanning/1](https://github.com/neocristal/hybridSOC/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/blank.yml` at the workflow root level (after `name:` and before `on:`), with least privilege needed for current behavior.

Best minimal fix without changing functionality:
- Add:
  - `permissions:`
  - `  contents: read`

This is sufficient for `actions/checkout@v4` and the existing shell echo steps. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
