### PR TITLE
docs: system architecture diagram and SRS/system design

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>HybridSOC — Documentation Index</title>
+<style>
+ body{font-family:system-ui,sans-serif;max-width:780px;margin:2rem auto;padding:0 1rem;color:#222}
+ h1{margin-bottom:.25rem}
+ small{color:#666}
+ ul{line-height:1.7}
+ code{background:#f4f4f4;padding:1px 4px;border-radius:3px}
+</style>
+</head>
+<body>
+<h1>HybridSOC — Documentation</h1>
+<small>MSIT 5270-01 Capstone · v2.0.0</small>
+
+<h2>System Architecture &amp; Design</h2>
+<ul>
+  <li><a href="system-design.md">system-design.md</a> — Combined SRS + System Design (~990 words): components, modules (I/O + methodology), FRs and NFRs.</li>
+  <li><a href="system-architecture.drawio">system-architecture.drawio</a> — Editable diagram (open at <a href="https://app.diagrams.net">app.diagrams.net</a> or with the VS Code Draw.io extension).</li>
+  <li><a href="system-architecture.mmd">system-architecture.mmd</a> — Mermaid source rendering the same architecture for in-repo viewing.</li>
+</ul>
+
+<h2>Background documents</h2>
+<ul>
+  <li><a href="../ARCHITECTURE.md">ARCHITECTURE.md</a> — Seven-layer model, data flow, MITRE ATT&amp;CK alignment.</li>
+  <li><a href="../AI.md">AI.md</a> — AI engine pipeline, ML models, EU AI Act controls.</li>
+  <li><a href="../INTEGRITY.md">INTEGRITY.md</a> — Data, model and process integrity model.</li>
+  <li><a href="../API.md">API.md</a> — REST API reference.</li>
+  <li><a href="../LITERATURE.md">LITERATURE.md</a> — Literature review and standards baseline.</li>
+</ul>
+</body>
+</html>

--- a/docs/system-architecture.drawio
+++ b/docs/system-architecture.drawio
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mxfile host="app.diagrams.net" modified="2026-04-26T00:00:00.000Z" agent="HybridSOC" version="24.0.0" type="device">
+  <diagram id="hybridsoc-arch" name="HybridSOC Architecture">
+    <mxGraphModel dx="1400" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1654" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+
+        <!-- TITLE -->
+        <mxCell id="title" value="HybridSOC v2.0.0 — System Architecture (Seven-Layer Model + Microservices)" style="text;html=1;align=center;verticalAlign=middle;fontSize=18;fontStyle=1;" vertex="1" parent="1">
+          <mxGeometry x="40" y="20" width="1180" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- L1 ENDPOINTS -->
+        <mxCell id="l1" value="L1 · Users / Devices / Endpoints" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1;verticalAlign=top;" vertex="1" parent="1">
+          <mxGeometry x="40" y="70" width="1180" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="l1a" value="Analysts &amp; Admins" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="80" y="100" width="180" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="l1b" value="Velociraptor / osquery" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="290" y="100" width="180" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="l1c" value="Wazuh Agents" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="500" y="100" width="180" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="l1d" value="Bitdefender / EDR" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="710" y="100" width="180" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="l1e" value="Browsers / Mobile / IoT" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="920" y="100" width="280" height="40" as="geometry" />
+        </mxCell>
+
+        <!-- L2 IDENTITY -->
+        <mxCell id="l2" value="L2 · Identity — IAM / SSO / MFA / PAM" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontStyle=1;verticalAlign=top;" vertex="1" parent="1">
+          <mxGeometry x="40" y="170" width="1180" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="l2a" value="Keycloak SSO (OIDC / SAML)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="80" y="200" width="240" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="l2b" value="HashiCorp Vault PAM" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="350" y="200" width="240" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="l2c" value="TOTP / Email OTP MFA" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="620" y="200" width="240" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="l2d" value="Entra ID Federation" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="890" y="200" width="310" height="40" as="geometry" />
+        </mxCell>
+
+        <!-- L3 ZERO TRUST -->
+        <mxCell id="l3" value="L3 · Zero Trust Gateway (NIST SP 800-207)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontStyle=1;verticalAlign=top;" vertex="1" parent="1">
+          <mxGeometry x="40" y="270" width="1180" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="l3a" value="ZTNA Policy Engine — continuous identity / device / context verification" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#d6b656;" vertex="1" parent="1">
+          <mxGeometry x="80" y="300" width="1120" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- L4 NETWORK -->
+        <mxCell id="l4" value="L4 · Network Security" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontStyle=1;verticalAlign=top;" vertex="1" parent="1">
+          <mxGeometry x="40" y="360" width="1180" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="l4a" value="OPNsense / pfSense Firewall" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="80" y="390" width="350" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="l4b" value="Suricata IDS/IPS" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="450" y="390" width="350" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="l4c" value="Zeek NSM (conn / dns / http logs)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#b85450;" vertex="1" parent="1">
+          <mxGeometry x="820" y="390" width="380" height="40" as="geometry" />
+        </mxCell>
+
+        <!-- L5 KAFKA -->
+        <mxCell id="l5" value="L5 · Kafka Streaming Backbone (telemetry fusion)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#e1d5e7;strokeColor=#9673a6;fontStyle=1;verticalAlign=top;" vertex="1" parent="1">
+          <mxGeometry x="40" y="460" width="1180" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="l5a" value="Topic: soc-alerts" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#9673a6;" vertex="1" parent="1">
+          <mxGeometry x="120" y="490" width="200" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="l5b" value="Topic: network-events" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#9673a6;" vertex="1" parent="1">
+          <mxGeometry x="380" y="490" width="220" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="l5c" value="Topic: network-flows" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#9673a6;" vertex="1" parent="1">
+          <mxGeometry x="660" y="490" width="220" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="l5d" value="Topic: api-logs" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#9673a6;" vertex="1" parent="1">
+          <mxGeometry x="940" y="490" width="220" height="40" as="geometry" />
+        </mxCell>
+
+        <!-- L6 ANALYTICS -->
+        <mxCell id="l6" value="L6 · SOC Analytics" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1;verticalAlign=top;" vertex="1" parent="1">
+          <mxGeometry x="40" y="560" width="1180" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="l6a" value="SIEM — Wazuh Manager + Elastic Stack&#xa;(50+ MITRE ATT&amp;CK correlation rules)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="80" y="590" width="350" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="l6b" value="Threat Intel — MISP + OpenCTI&#xa;IoC enrichment / TIP feeds" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#6c8ebf;" vertex="1" parent="1">
+          <mxGeometry x="450" y="590" width="350" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="l6c" value="AI Engine :8000 — FastAPI&#xa;Isolation Forest · LSTM · Graph ML&#xa;FAISS RAG · Mistral-7B" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" vertex="1" parent="1">
+          <mxGeometry x="820" y="590" width="380" height="70" as="geometry" />
+        </mxCell>
+
+        <!-- L7 RESPONSE + GRC -->
+        <mxCell id="l7" value="L7 · Automation, Response &amp; GRC" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;fontStyle=1;verticalAlign=top;" vertex="1" parent="1">
+          <mxGeometry x="40" y="700" width="1180" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="l7a" value="SOAR — TheHive + Cortex + Shuffle&#xa;(case mgmt · analysers · playbooks)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="80" y="730" width="350" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="l7b" value="GRC Engine :8001&#xa;ISO 27001 · DORA · NIS2 · GDPR · EU AI Act&#xa;Risk register · TPRM · timers" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" vertex="1" parent="1">
+          <mxGeometry x="450" y="730" width="350" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="l7c" value="DocGen + Reporting&#xa;DPIA · BCP · IR reports (DOCX/PDF)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffffff;strokeColor=#82b366;" vertex="1" parent="1">
+          <mxGeometry x="820" y="730" width="380" height="70" as="geometry" />
+        </mxCell>
+
+        <!-- CONTROL PLANE -->
+        <mxCell id="cp" value="Control Plane (Microservices)" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;fontStyle=1;verticalAlign=top;" vertex="1" parent="1">
+          <mxGeometry x="40" y="840" width="1180" height="100" as="geometry" />
+        </mxCell>
+        <mxCell id="cpa" value="API Gateway :8080 (FastAPI)&#xa;auth · rate-limit · routing" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" vertex="1" parent="1">
+          <mxGeometry x="80" y="870" width="350" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="cpb" value="Admin API + Dashboard :8002&#xa;users · tenants · KPIs · charts" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ffe6cc;strokeColor=#d79b00;" vertex="1" parent="1">
+          <mxGeometry x="450" y="870" width="350" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="cpc" value="Persistence: SQLite WAL (hash-chain audit) · Elasticsearch · Git-LFS model store" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#666666;" vertex="1" parent="1">
+          <mxGeometry x="820" y="870" width="380" height="60" as="geometry" />
+        </mxCell>
+
+        <!-- DEPLOYMENT TOPOLOGY -->
+        <mxCell id="dep" value="Hybrid Deployment — On-Prem (Wazuh, Keycloak, OPNsense, EDR)  ↔  Cloud (Elastic, Kafka, K8s, AI Engine)  ↔  MSSP (TI sharing, shared SOC)" style="text;html=1;align=center;verticalAlign=middle;fontStyle=2;fontSize=12;" vertex="1" parent="1">
+          <mxGeometry x="40" y="950" width="1180" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- VERTICAL FLOW ARROWS (left edge) -->
+        <mxCell id="e1" style="endArrow=classic;html=1;strokeColor=#444;strokeWidth=2;" edge="1" parent="1" source="l1" target="l2">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e2" style="endArrow=classic;html=1;strokeColor=#444;strokeWidth=2;" edge="1" parent="1" source="l2" target="l3">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e3" style="endArrow=classic;html=1;strokeColor=#444;strokeWidth=2;" edge="1" parent="1" source="l3" target="l4">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e4" style="endArrow=classic;html=1;strokeColor=#444;strokeWidth=2;" edge="1" parent="1" source="l4" target="l5">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e5" style="endArrow=classic;html=1;strokeColor=#444;strokeWidth=2;" edge="1" parent="1" source="l5" target="l6">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e6" style="endArrow=classic;html=1;strokeColor=#444;strokeWidth=2;" edge="1" parent="1" source="l6" target="l7">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="e7" style="endArrow=classic;html=1;strokeColor=#444;strokeWidth=2;" edge="1" parent="1" source="l7" target="cp">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- AI -> SOAR escalation (annotated) -->
+        <mxCell id="ea" value="risk_score ≥ 75" style="endArrow=classic;html=1;strokeColor=#d79b00;strokeWidth=2;dashed=1;fontColor=#7f5800;fontSize=11;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="l6c" target="l7a">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/docs/system-architecture.mmd
+++ b/docs/system-architecture.mmd
@@ -1,0 +1,94 @@
+%% HybridSOC v2.0.0 — System Architecture (Mermaid)
+%% Render with mermaid-cli or any markdown viewer that supports mermaid.
+flowchart TB
+    %% ─── Layer 1: Endpoints ───
+    subgraph L1["L1 · Users / Devices / Endpoints"]
+        U[Analysts & Admins]
+        EP[Velociraptor / osquery / Wazuh agents]
+    end
+
+    %% ─── Layer 2: Identity ───
+    subgraph L2["L2 · Identity (IAM / SSO / MFA / PAM)"]
+        KC[Keycloak SSO]
+        VLT[HashiCorp Vault PAM]
+        MFA[TOTP MFA]
+    end
+
+    %% ─── Layer 3: Zero Trust ───
+    subgraph L3["L3 · Zero Trust Gateway (NIST SP 800-207)"]
+        ZTG[Policy Engine + ZTNA]
+    end
+
+    %% ─── Layer 4: Network ───
+    subgraph L4["L4 · Network Security"]
+        FW[OPNsense Firewall]
+        IDS[Suricata IDS/IPS]
+        ZK[Zeek NSM]
+    end
+
+    %% ─── Layer 5: Telemetry ───
+    subgraph L5["L5 · Kafka Streaming Backbone"]
+        K1[(soc-alerts)]
+        K2[(network-events)]
+        K3[(api-logs)]
+    end
+
+    %% ─── Layer 6: Analytics ───
+    subgraph L6["L6 · SOC Analytics"]
+        SIEM[Wazuh + Elastic SIEM]
+        TI[MISP + OpenCTI]
+        AI[AI Engine :8000<br/>Isolation Forest · LSTM · FAISS RAG · Mistral-7B]
+    end
+
+    %% ─── Layer 7: Response & GRC ───
+    subgraph L7["L7 · Response & GRC"]
+        SOAR[TheHive + Cortex + Shuffle]
+        GRC[GRC Engine :8001<br/>ISO 27001 · DORA · NIS2 · GDPR · EU AI Act]
+        DOC[DocGen — DPIA / BCP / IR Reports]
+    end
+
+    %% ─── Microservices control plane ───
+    subgraph CP["Control Plane"]
+        GW[API Gateway :8080]
+        ADMIN[Admin API + Dashboard :8002]
+    end
+
+    %% ─── Persistence ───
+    subgraph DS["Persistence"]
+        ES[(Elasticsearch)]
+        DB[(SQLite WAL · hash-chain audit)]
+    end
+
+    %% ─── Edges ───
+    U -->|login| KC
+    KC --> MFA --> ZTG
+    VLT --> ZTG
+    EP --> L4
+    L4 --> K1
+    L4 --> K2
+    GW --> K3
+    K1 --> SIEM
+    K1 --> AI
+    K2 --> SIEM
+    K2 --> TI
+    K3 --> GRC
+    SIEM --> AI
+    TI --> AI
+    AI -->|score >= 75| SOAR
+    AI --> GRC
+    SIEM --> GRC
+    SOAR --> GRC
+    GRC --> DOC
+    GW <--> AI
+    GW <--> GRC
+    GW <--> ADMIN
+    AI --> DB
+    GRC --> DB
+    SIEM --> ES
+    ADMIN --> DB
+    ZTG --> GW
+
+    classDef layer fill:#0b3d91,stroke:#0b3d91,color:#ffffff
+    classDef store fill:#444,stroke:#222,color:#fff
+    class L1,L2,L3,L4,L5,L6,L7,CP layer
+    class ES,DB store

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -1,0 +1,98 @@
+# HybridSOC — System Requirements Specification & System Design
+
+> MSIT 5270-01 Capstone | Combined SRS and System Design
+> Companion: `docs/system-architecture.drawio`, `docs/system-architecture.mmd`
+
+---
+
+## 1. Introduction
+
+Traditional SOCs rely on static, signature-based detection that produces high alert volumes, slow MTTR, and weak alignment with the EU regulatory stack (DORA, NIS2, GDPR, EU AI Act). HybridSOC addresses this gap with an **AI-augmented, Zero-Trust, GRC-integrated** SOC. The platform fuses telemetry from endpoints, network sensors, and identity systems into a Kafka backbone, applies ML analytics, and routes prioritised events to SOAR playbooks — while continuously mapping every event to compliance obligations and preserving human-in-the-loop oversight (Mohsin et al., 2025).
+
+---
+
+## 2. System Components and Interactions
+
+The platform is structured as a **seven-layer stack** with three horizontal microservices.
+
+| Layer | Components | Interaction |
+|---|---|---|
+| L1 Endpoint | Velociraptor, osquery, Wazuh agents | Push telemetry to L5 |
+| L2 Identity | Keycloak SSO, HashiCorp Vault PAM, TOTP MFA | Issues tokens consumed by L3 |
+| L3 Zero-Trust Gateway | ZTNA policy engine (NIST SP 800-207) | Verifies every API call |
+| L4 Network | OPNsense, Suricata IDS/IPS, Zeek NSM | Emits flows/alerts to L5 |
+| L5 Telemetry | Kafka topics (`soc-alerts`, `network-events`, `api-logs`) | Streams to L6 |
+| L6 Analytics | Wazuh + Elastic SIEM, MISP/OpenCTI TI, AI Engine | Produces risk scores |
+| L7 Response & GRC | TheHive + Cortex + Shuffle SOAR, GRC Engine | Triggers playbooks, files reports |
+
+Cross-cutting microservices — **API Gateway (:8080)**, **AI Engine (:8000)**, **GRC Engine (:8001)** — communicate over REST/JSON with mutual auth, with SQLite (WAL + hash-chain) and Elasticsearch as the persistence tier.
+
+---
+
+## 3. Module-Wise Functional Specification
+
+### 3.1 Identity & Access
+- **In:** credentials, TOTP, SSO assertions. **Out:** bearer token, RBAC claims, audit entry.
+- **Method:** PBKDF2-SHA256, TOTP RFC 6238, Keycloak OIDC, Vault secret brokering.
+
+### 3.2 Telemetry Ingestion
+- **In:** Wazuh alerts, Suricata `eve.json`, Zeek conn logs, EDR events. **Out:** normalised JSON on Kafka.
+- **Method:** Beats shippers → Kafka producers → schema validation → Elasticsearch indexing.
+
+### 3.3 AI Risk-Scoring (`services/ai-engine`)
+- **In:** event `{user, activity, ip, bytes, timestamp}` (`POST /risk`). **Out:** score 0–100, features, regulatory tags, explanation.
+- **Method:** Isolation Forest (anomaly), LSTM (UEBA), graph ML (lateral movement), FAISS RAG for regulatory enrichment, Mistral-7B for commentary. Scores ≥ 75 escalate to SOAR; ≥ 90 require analyst review within 1 h (EU AI Act Art. 14).
+
+### 3.4 SIEM & Threat Intelligence
+- **In:** Kafka streams, MISP/OpenCTI feeds. **Out:** alerts mapped to MITRE ATT&CK.
+- **Method:** 50+ Wazuh correlation rules, IoC enrichment via Cortex analysers.
+
+### 3.5 SOAR Orchestration
+- **In:** AI score above threshold or analyst trigger. **Out:** TheHive case + Shuffle playbook (IP block, account quarantine).
+- **Method:** TheHive REST + Cortex + Shuffle; each action logged with score and approver.
+
+### 3.6 GRC Engine (`services/grc-engine`)
+- **In:** L6 events, document uploads, risk register entries. **Out:** per-framework scores, DORA Art. 17 / NIS2 Art. 21 timers, DPIA/BCP DOCX/PDF.
+- **Method:** rule-based severity-weighted scoring, FAISS RAG over regulatory corpora, timer state-machine.
+
+### 3.7 Admin API & Dashboard (`services/api`)
+- **In:** admin actions, dashboard queries. **Out:** KPI charts (MTTR, severity, heatmap), user/role/tenant CRUD.
+- **Method:** FastAPI + static frontend at `/dashboard`, Bearer-token auth with MFA challenge.
+
+### 3.8 Integrity Module
+- **In:** every write across services. **Out:** append-only audit row with `prev_hash`/`row_hash`.
+- **Method:** SHA-256 chain over SQLite WAL; GPG-signed model artefacts verified at load.
+
+---
+
+## 4. Functional Requirements (FRs)
+
+| ID | Requirement |
+|---|---|
+| FR-1 | The system shall authenticate users via SSO + MFA before granting any API access. |
+| FR-2 | The system shall ingest telemetry from Wazuh, Suricata, Zeek, and EDR agents in near real-time (≤ 5 s end-to-end). |
+| FR-3 | The AI engine shall return a risk score for any submitted event within 500 ms (p95). |
+| FR-4 | Risk scores ≥ 75 shall automatically create a TheHive case; scores ≥ 90 shall additionally trigger a Shuffle playbook. |
+| FR-5 | The GRC engine shall start DORA Art. 17 (72 h) and NIS2 Art. 21 timers when an ICT incident is registered. |
+| FR-6 | The system shall expose REST endpoints for risk scoring, document upload, risk register, TPRM, audit log, and admin management. |
+| FR-7 | Every action shall be written to the immutable hash-chained audit log. |
+| FR-8 | The system shall generate DPIA, BCP, and incident reports as DOCX/PDF on demand. |
+
+## 5. Non-Functional Requirements (NFRs)
+
+| Category | Requirement |
+|---|---|
+| **Performance** | API gateway p95 latency ≤ 200 ms; AI inference p95 ≤ 500 ms; Kafka ingestion ≥ 10 k events/s per broker. |
+| **Scalability** | Horizontal scaling via Kubernetes + ArgoCD; stateless microservices behind the API gateway; Kafka partitioning by tenant. |
+| **Reliability** | DORA Art. 11 ICT-resilience target: 99.9 % availability; hybrid on-prem/cloud failover; backup retention 12 months. |
+| **Security** | Zero-Trust per NIST SP 800-207; TLS 1.3 everywhere; PBKDF2-SHA256 secrets; GPG-signed ML models; least-privilege RBAC. |
+| **Usability** | Analyst dashboard reachable in ≤ 3 clicks from login; OpenAPI docs at `/docs`; localisation-ready UI. |
+| **Compliance** | Continuous mapping to ISO 27001 A.5/A.8, DORA Art. 6/9/11/17/28, NIS2 Art. 21, GDPR Art. 5/33/35, EU AI Act Art. 6/13/14. |
+| **Maintainability** | Containerised microservices, Helm/Kustomize manifests, CI on every PR, SBOM per release. |
+| **Auditability** | Hash-chained audit log with tamper detection on read; quarterly bias and drift review of all ML models. |
+
+---
+
+## 6. Design Trade-offs
+
+The hybrid (cloud + on-prem + MSSP) topology was chosen over a pure-cloud SOC because Zeijlemaker et al. (2025) show feedback loops between local telemetry and cloud analytics improve detection of two-step and autonomous attack chains. SQLite-WAL keeps the dev footprint small while satisfying append-only audit needs; production swaps it for PostgreSQL behind the same SQLAlchemy interface. Mistral-7B is used only for commentary — never for autonomous enforcement — to remain within EU AI Act Art. 14.


### PR DESCRIPTION
## Summary

Adds the System Architecture Blueprint and Module Design assignment artefacts under `docs/`:

- **`docs/system-design.md`** — Combined SRS + System Design (~990 words) covering:
  - Components and interactions across the seven-layer model
  - Module-wise breakdown (Identity, Telemetry, AI Risk-Scoring, SIEM/TI, SOAR, GRC, Admin/Dashboard, Integrity) with Input / Output / Methodology for each
  - 8 Functional Requirements (FR-1 … FR-8)
  - Non-Functional Requirements across Performance, Scalability, Reliability, Security, Usability, Compliance, Maintainability, Auditability
  - Design trade-offs (hybrid topology, persistence choice, LLM scope)
- **`docs/system-architecture.drawio`** — Editable Draw.io diagram of the seven-layer architecture (L1 Endpoints → L7 Response/GRC), Kafka topics, control-plane microservices (API Gateway :8080, AI Engine :8000, GRC Engine :8001, Admin API :8002), persistence tier, and the annotated AI → SOAR escalation edge (`risk_score ≥ 75`).
- **`docs/system-architecture.mmd`** — Mermaid source of the same architecture for in-repo viewing.
- **`docs/index.html`** — Documentation landing page linking the architecture artefacts.

Aligns with NIST SP 800-207 (Zero Trust), MITRE ATT&CK, ISO/IEC 27001:2022, DORA, NIS2, GDPR, and EU AI Act controls already referenced in `ARCHITECTURE.md`, `AI.md`, and `INTEGRITY.md`.

## Test plan

- [x] Open `docs/system-architecture.drawio` in [app.diagrams.net](https://app.diagrams.net) and confirm the diagram renders with all seven layers and the dashed AI→SOAR escalation edge.
- [x] Render `docs/system-architecture.mmd` in any Mermaid-aware viewer and confirm it shows the same component graph.
- [x] Verify `docs/system-design.md` word count is within the 750–1000 range (`wc -w docs/system-design.md` → 990).
- [x] Open `docs/index.html` and confirm all relative links resolve.

---
_Generated by [Claude Code](https://claude.ai/code/session_017yh2aHGgJegs288NP9G7Ux)_