### PR TITLE
feat: bun JS toolchain, Windows PowerShell installer, DB schema doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,20 +134,36 @@ hashing (260 000 iterations + per-user salt + global pepper), TOTP MFA, Email
 OTP, and Cloudflare Turnstile. Frontend: React 18.3 / Vite, plain JSX with
 inline CSS. Full reference: [`services/web/README.md`](services/web/README.md).
 
-#### One-shot install (Linux/macOS)
+#### One-shot install
+
+JS toolchain: **Bun** is preferred (faster install, single binary). Both
+installers fall back to Node.js 20.x + npm if Bun is unavailable.
+
+**Linux / macOS (bash):**
 
 ```bash
 bash scripts/install-web.sh           # backend + frontend build
-bash scripts/install-web.sh --dev     # backend + npm install only (no build)
+bash scripts/install-web.sh --dev     # deps only, skip build
 bash scripts/install-web.sh --no-frontend
 ```
 
-The script detects Python 3.10+, installs Node.js 20.x via NodeSource on
-Debian/Ubuntu when missing, creates `services/web/.venv`, installs Python deps,
-seeds `services/web/.env` with a freshly generated `FLASK_SECRET_KEY` and
-`HYBRIDSOC_PEPPER`, runs migrations, and bootstraps the superadmin.
+**Windows (PowerShell):**
+
+```powershell
+.\scripts\install-web.ps1             # backend + frontend build
+.\scripts\install-web.ps1 -Dev
+.\scripts\install-web.ps1 -NoFrontend
+# If blocked: Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+```
+
+Both scripts detect Python 3.10+, ensure a JS runtime is present (Bun
+preferred, Node.js fallback), create `services/web/.venv`, install Python
+deps, seed `services/web/.env` with a generated `FLASK_SECRET_KEY` and
+`HYBRIDSOC_PEPPER`, run migrations, and bootstrap the superadmin.
 
 #### Start the backend (Flask)
+
+**Linux / macOS:**
 
 ```bash
 cd services/web
@@ -157,31 +173,46 @@ python -m services.web.migrate                # apply pending migrations (idempo
 python -m services.web.app                    # http://localhost:5000
 ```
 
-The Flask app serves the built React bundle on the same port, so once the
-frontend has been built the dashboard is reachable directly at
-`http://localhost:5000/`. Health probe: `GET /api/health`.
+**Windows (PowerShell):**
 
-For production / multi-worker:
+```powershell
+cd services\web
+.\.venv\Scripts\Activate.ps1
+Get-Content .env | ForEach-Object { if ($_ -match '^([^=]+)=(.*)') { [Environment]::SetEnvironmentVariable($matches[1], $matches[2], 'Process') } }
+python -m services.web.migrate
+python -m services.web.app                    # http://localhost:5000
+```
+
+Flask serves the built React bundle on the same port — once built, the
+dashboard is reachable at `http://localhost:5000/`. Health probe: `GET /api/health`.
+
+For production multi-worker (Linux/macOS):
 
 ```bash
 gunicorn -w 4 -b 0.0.0.0:5000 'services.web.app:create_app()'
 ```
 
+On Windows use `waitress` (`pip install waitress; waitress-serve --listen=0.0.0.0:5000 'services.web.app:create_app()'`)
+or run behind IIS.
+
 #### Start the frontend (React + Vite)
 
-For hot-reload during development (separate terminal from the backend):
+**Bun (preferred — works identically on Linux/macOS/Windows):**
 
 ```bash
 cd services/web/frontend
-npm install                                   # first time only
-npm run dev                                   # http://localhost:5173 → /api proxied to :5000
+bun install                                   # first time only
+bun run dev                                   # http://localhost:5173 → /api proxied to :5000
+bun run build                                 # production output to ./dist
 ```
 
-For a production build (output is served by Flask from `frontend/dist/`):
+**npm fallback:**
 
 ```bash
 cd services/web/frontend
-npm run build                                 # produces ./dist
+npm install
+npm run dev
+npm run build
 ```
 
 Then start Flask as above and open `http://localhost:5000/`.

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -1,0 +1,473 @@
+# HybridSOC — SQLite Database Schema
+
+> Companion to [`system-design.md`](system-design.md) and [`../INTEGRITY.md`](../INTEGRITY.md).
+> Source of truth: `services/web/migrations/*.sql`.
+> Visual diagram: [`database-schema.drawio`](database-schema.drawio).
+
+---
+
+## 1. Overview
+
+The HybridSOC web service uses a single SQLite database operating in **WAL
+mode** with `foreign_keys=ON` and `synchronous=NORMAL`. It backs:
+
+- IAM (users, sessions, MFA secrets, OTP one-time codes)
+- Multi-tenancy (`tenants`)
+- GRC (risks, incidents, vendors)
+- An append-only, hash-chained audit trail (`audit_log`)
+- The migration ledger (`schema_migrations`)
+
+WAL was chosen because it allows concurrent readers (analyst dashboard
+queries) while a single writer (the API) appends rows. The SHA-256
+`prev_hash` / `row_hash` chain on `audit_log` gives tamper-evidence
+without a separate ledger system (see INTEGRITY.md §2.1).
+
+### Connection PRAGMA settings (`services/web/db.py`)
+
+```sql
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous  = NORMAL;
+PRAGMA foreign_keys = ON;
+```
+
+---
+
+## 2. Entity-Relationship overview
+
+```mermaid
+erDiagram
+    TENANTS ||--o{ USERS : "tenant_id"
+    USERS   ||--o{ SESSIONS : "user_id (CASCADE)"
+    USERS   ||--o{ EMAIL_OTP : "user_id (CASCADE)"
+    USERS   ||--o{ RISKS : "owner_id (SET NULL)"
+    USERS   ||--o{ INCIDENTS : "owner_id (SET NULL)"
+    USERS   ||--o{ AUDIT_LOG : "user_id (no FK)"
+    AUDIT_LOG ||--|| AUDIT_LOG : "prev_hash chain"
+
+    TENANTS {
+        INTEGER  id PK
+        TEXT     name UK
+        DATETIME created_at
+    }
+    USERS {
+        INTEGER  id PK
+        TEXT     email UK
+        TEXT     password_salt
+        TEXT     password_hash
+        TEXT     role
+        INTEGER  active
+        TEXT     totp_secret
+        INTEGER  totp_enabled
+        INTEGER  tenant_id FK
+        DATETIME created_at
+    }
+    SESSIONS {
+        INTEGER  id PK
+        INTEGER  user_id FK
+        TEXT     token_hash UK
+        DATETIME created_at
+        DATETIME expires_at
+    }
+    EMAIL_OTP {
+        INTEGER  id PK
+        INTEGER  user_id FK
+        TEXT     code_hash
+        INTEGER  consumed
+        DATETIME created_at
+        DATETIME expires_at
+    }
+    AUDIT_LOG {
+        INTEGER  id PK
+        INTEGER  user_id
+        TEXT     action
+        TEXT     details
+        TEXT     ip_address
+        DATETIME timestamp
+        TEXT     prev_hash
+        TEXT     row_hash
+    }
+    RISKS {
+        INTEGER  id PK
+        TEXT     title
+        INTEGER  likelihood
+        INTEGER  impact
+        TEXT     framework
+        TEXT     article
+        TEXT     treatment
+        TEXT     status
+        INTEGER  owner_id FK
+        DATETIME created_at
+    }
+    INCIDENTS {
+        INTEGER  id PK
+        TEXT     title
+        TEXT     severity
+        TEXT     type
+        TEXT     frameworks
+        TEXT     status
+        DATETIME dora_deadline
+        DATETIME nis2_deadline
+        INTEGER  owner_id FK
+        DATETIME created_at
+    }
+    VENDORS {
+        INTEGER  id PK
+        TEXT     name UK
+        TEXT     criticality
+        INTEGER  dora_art28
+        TEXT     services
+        DATETIME created_at
+    }
+    SCHEMA_MIGRATIONS {
+        TEXT     name PK
+        DATETIME applied_at
+    }
+```
+
+---
+
+## 3. Tables
+
+### 3.1 `tenants` — multi-tenant boundary
+
+| Column     | Type     | Constraints                     | Notes |
+|------------|----------|---------------------------------|-------|
+| id         | INTEGER  | PK, AUTOINCREMENT                | tenant id |
+| name       | TEXT     | NOT NULL, UNIQUE                 | display name |
+| created_at | DATETIME | DEFAULT CURRENT_TIMESTAMP        | audit |
+
+```sql
+CREATE TABLE tenants (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT NOT NULL UNIQUE,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### 3.2 `users` — identity store
+
+| Column         | Type     | Constraints                                                | Notes |
+|----------------|----------|------------------------------------------------------------|-------|
+| id             | INTEGER  | PK, AUTOINCREMENT                                           | user id |
+| email          | TEXT     | NOT NULL, UNIQUE                                            | login id (lowercased) |
+| password_salt  | TEXT     | NOT NULL                                                    | base64 16-byte salt |
+| password_hash  | TEXT     | NOT NULL                                                    | base64 PBKDF2-SHA256 (260 000 iter) of `password + PEPPER` |
+| role           | TEXT     | NOT NULL, DEFAULT `'analyst'`                              | analyst / manager / compliance / admin / superadmin |
+| active         | INTEGER  | NOT NULL, DEFAULT 1                                         | soft-delete flag |
+| totp_secret    | TEXT     | NULL                                                        | base32 RFC 6238 secret |
+| totp_enabled   | INTEGER  | NOT NULL, DEFAULT 0                                         | 1 once activated |
+| tenant_id      | INTEGER  | FK → tenants(id) ON DELETE SET NULL                         | nullable |
+| created_at     | DATETIME | DEFAULT CURRENT_TIMESTAMP                                   | audit |
+
+```sql
+CREATE TABLE users (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    email           TEXT NOT NULL UNIQUE,
+    password_salt   TEXT NOT NULL,
+    password_hash   TEXT NOT NULL,
+    role            TEXT NOT NULL DEFAULT 'analyst',
+    active          INTEGER NOT NULL DEFAULT 1,
+    totp_secret     TEXT,
+    totp_enabled    INTEGER NOT NULL DEFAULT 0,
+    tenant_id       INTEGER REFERENCES tenants(id) ON DELETE SET NULL,
+    created_at      DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+The global `HYBRIDSOC_PEPPER` is **not** stored in the database — it is read
+from the environment so a DB-only leak is insufficient for an offline attack.
+
+### 3.3 `sessions` — Bearer-token store (hashed)
+
+| Column     | Type     | Constraints                                       | Notes |
+|------------|----------|---------------------------------------------------|-------|
+| id         | INTEGER  | PK, AUTOINCREMENT                                  | session id |
+| user_id    | INTEGER  | NOT NULL, FK → users(id) ON DELETE CASCADE         | owner |
+| token_hash | TEXT     | NOT NULL, UNIQUE                                   | SHA-256 of the raw token |
+| created_at | DATETIME | DEFAULT CURRENT_TIMESTAMP                          | issued |
+| expires_at | DATETIME | NOT NULL                                           | TTL = `SESSION_TTL_SECONDS` (default 8 h) |
+
+```sql
+CREATE TABLE sessions (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash  TEXT NOT NULL UNIQUE,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    expires_at  DATETIME NOT NULL
+);
+CREATE INDEX idx_sessions_user ON sessions(user_id);
+```
+
+### 3.4 `email_otp` — one-time MFA codes
+
+| Column     | Type     | Constraints                                       | Notes |
+|------------|----------|---------------------------------------------------|-------|
+| id         | INTEGER  | PK, AUTOINCREMENT                                  | OTP id |
+| user_id    | INTEGER  | NOT NULL, FK → users(id) ON DELETE CASCADE         | recipient |
+| code_hash  | TEXT     | NOT NULL                                           | SHA-256 of the 6-digit code |
+| consumed   | INTEGER  | NOT NULL, DEFAULT 0                                | 1 after successful verify |
+| created_at | DATETIME | DEFAULT CURRENT_TIMESTAMP                          | issued |
+| expires_at | DATETIME | NOT NULL                                           | TTL = `OTP_TTL_SECONDS` (default 5 min) |
+
+```sql
+CREATE TABLE email_otp (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    code_hash   TEXT NOT NULL,
+    consumed    INTEGER NOT NULL DEFAULT 0,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    expires_at  DATETIME NOT NULL
+);
+CREATE INDEX idx_email_otp_user ON email_otp(user_id);
+```
+
+### 3.5 `audit_log` — append-only hash-chained trail
+
+| Column     | Type     | Constraints                | Notes |
+|------------|----------|----------------------------|-------|
+| id         | INTEGER  | PK, AUTOINCREMENT           | row id |
+| user_id    | INTEGER  | NULL                        | actor (NULL for failed login attempts) |
+| action     | TEXT     | NOT NULL                    | event name (e.g. `login_password_ok`) |
+| details    | TEXT     | NULL                        | free-form context |
+| ip_address | TEXT     | NULL                        | client IP |
+| timestamp  | DATETIME | DEFAULT CURRENT_TIMESTAMP   | UTC |
+| prev_hash  | TEXT     | NOT NULL                    | SHA-256 of the previous row's `row_hash` (genesis = 64 × `0`) |
+| row_hash   | TEXT     | NOT NULL                    | SHA-256(`prev_hash` ‖ canonical JSON of payload) |
+
+Deliberately **no** foreign key on `user_id`: rows must survive user deletion
+to satisfy the immutability requirement.
+
+```sql
+CREATE TABLE audit_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER,
+    action      TEXT NOT NULL,
+    details     TEXT,
+    ip_address  TEXT,
+    timestamp   DATETIME DEFAULT CURRENT_TIMESTAMP,
+    prev_hash   TEXT NOT NULL,
+    row_hash    TEXT NOT NULL
+);
+CREATE INDEX idx_audit_user   ON audit_log(user_id);
+CREATE INDEX idx_audit_action ON audit_log(action);
+```
+
+Hash-chain construction (see `services/web/audit.py`):
+
+```python
+canonical = json.dumps({"user_id":..., "action":..., "details":..., "ip_address":...},
+                       sort_keys=True, separators=(",", ":"))
+row_hash  = sha256(prev_hash + canonical).hexdigest()
+```
+
+`/api/audit/verify` re-walks the chain and reports the first row where
+`prev_hash` or the recomputed `row_hash` mismatch.
+
+### 3.6 `risks` — risk register
+
+| Column     | Type     | Constraints                                          | Notes |
+|------------|----------|------------------------------------------------------|-------|
+| id         | INTEGER  | PK, AUTOINCREMENT                                     | risk id |
+| title      | TEXT     | NOT NULL                                              | description |
+| likelihood | INTEGER  | NOT NULL, CHECK BETWEEN 1 AND 5                       | ISO 31000 |
+| impact     | INTEGER  | NOT NULL, CHECK BETWEEN 1 AND 5                       | ISO 31000 |
+| framework  | TEXT     | NULL                                                  | DORA / NIS2 / ISO27001 / GDPR / EUAI |
+| article    | TEXT     | NULL                                                  | e.g. `Art.28` |
+| treatment  | TEXT     | NULL                                                  | mitigation plan |
+| status     | TEXT     | NOT NULL, DEFAULT `'open'`                           | open / mitigated / accepted |
+| owner_id   | INTEGER  | FK → users(id) ON DELETE SET NULL                     | nullable |
+| created_at | DATETIME | DEFAULT CURRENT_TIMESTAMP                             | audit |
+
+```sql
+CREATE TABLE risks (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    title       TEXT NOT NULL,
+    likelihood  INTEGER NOT NULL CHECK (likelihood BETWEEN 1 AND 5),
+    impact      INTEGER NOT NULL CHECK (impact BETWEEN 1 AND 5),
+    framework   TEXT,
+    article     TEXT,
+    treatment   TEXT,
+    status      TEXT NOT NULL DEFAULT 'open',
+    owner_id    INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### 3.7 `incidents` — ICT / NIS2 / GDPR incidents
+
+| Column        | Type     | Constraints                                       | Notes |
+|---------------|----------|---------------------------------------------------|-------|
+| id            | INTEGER  | PK, AUTOINCREMENT                                  | incident id |
+| title         | TEXT     | NOT NULL                                           |  |
+| severity      | TEXT     | NOT NULL, DEFAULT `'Medium'`                      | Low / Medium / High / Critical |
+| type          | TEXT     | NOT NULL, DEFAULT `'ICT_INCIDENT'`                | ICT_INCIDENT / SIGNIFICANT_INCIDENT / DATA_BREACH |
+| frameworks    | TEXT     | NULL                                               | comma-separated DORA,NIS2 |
+| status        | TEXT     | NOT NULL, DEFAULT `'open'`                        |  |
+| dora_deadline | DATETIME | NULL                                               | DORA Art. 17 — `created_at + 72 h` |
+| nis2_deadline | DATETIME | NULL                                               | NIS2 Art. 21 — `created_at + 24 h` |
+| owner_id      | INTEGER  | FK → users(id) ON DELETE SET NULL                  | reporter |
+| created_at    | DATETIME | DEFAULT CURRENT_TIMESTAMP                          | audit |
+
+```sql
+CREATE TABLE incidents (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    title           TEXT NOT NULL,
+    severity        TEXT NOT NULL DEFAULT 'Medium',
+    type            TEXT NOT NULL DEFAULT 'ICT_INCIDENT',
+    frameworks      TEXT,
+    status          TEXT NOT NULL DEFAULT 'open',
+    dora_deadline   DATETIME,
+    nis2_deadline   DATETIME,
+    owner_id        INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    created_at      DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### 3.8 `vendors` — Third-Party Risk Management (DORA Art. 28)
+
+| Column      | Type     | Constraints                          | Notes |
+|-------------|----------|--------------------------------------|-------|
+| id          | INTEGER  | PK, AUTOINCREMENT                     | vendor id |
+| name        | TEXT     | NOT NULL, UNIQUE                      | display name |
+| criticality | TEXT     | NOT NULL, DEFAULT `'Medium'`         | Low / Medium / High / Critical |
+| dora_art28  | INTEGER  | NOT NULL, DEFAULT 0                   | 1 if subject to DORA Art. 28 |
+| services    | TEXT     | NULL                                  | comma-separated services |
+| created_at  | DATETIME | DEFAULT CURRENT_TIMESTAMP             | audit |
+
+```sql
+CREATE TABLE vendors (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT NOT NULL UNIQUE,
+    criticality TEXT NOT NULL DEFAULT 'Medium',
+    dora_art28  INTEGER NOT NULL DEFAULT 0,
+    services    TEXT,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### 3.9 `schema_migrations` — migration ledger
+
+Created automatically by `services/web/db.py::run_migrations` before any
+user migration is applied.
+
+```sql
+CREATE TABLE schema_migrations (
+    name        TEXT PRIMARY KEY,
+    applied_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+---
+
+## 4. Indexes
+
+| Index              | Table     | Columns    | Reason |
+|--------------------|-----------|------------|--------|
+| `idx_sessions_user`  | sessions  | user_id    | revoke-all-sessions / list per user |
+| `idx_email_otp_user` | email_otp | user_id    | latest unconsumed OTP lookup |
+| `idx_audit_user`     | audit_log | user_id    | per-user activity timeline |
+| `idx_audit_action`   | audit_log | action     | filter by event type |
+
+`UNIQUE` constraints (`tenants.name`, `users.email`, `sessions.token_hash`,
+`vendors.name`) are also implicitly indexed by SQLite.
+
+---
+
+## 5. Retention policy (GDPR Art. 5(1)(c) / (e))
+
+Drawn from INTEGRITY.md §2.3 — enforced by scheduled purge jobs:
+
+| Table       | Retention                | Justification |
+|-------------|--------------------------|---------------|
+| `audit_log` | 12 months                | ISO 27001 A.8.15 / NIS2 Art. 21 |
+| `sessions`  | until `expires_at`       | GDPR Art. 5(1)(e) |
+| `email_otp` | until `expires_at`       | minimal exposure |
+| `risks`     | indefinite while open    | GRC requirement |
+| `incidents` | 24 months after closure  | DORA Art. 9 |
+
+A rolling 90-day pseudonymisation step applies to `users.email` for inactive
+accounts (planned).
+
+---
+
+## 6. Reference queries
+
+```sql
+-- Active session for a token (constant-time hash compare in code)
+SELECT u.id, u.email, u.role, u.totp_enabled
+  FROM sessions s
+  JOIN users u ON u.id = s.user_id
+ WHERE s.token_hash = ? AND s.expires_at > datetime('now');
+
+-- Latest unconsumed OTP for a user
+SELECT id, code_hash
+  FROM email_otp
+ WHERE user_id = ? AND consumed = 0
+   AND expires_at > datetime('now')
+ ORDER BY id DESC LIMIT 1;
+
+-- Risk register sorted by inherent risk (likelihood × impact)
+SELECT id, title, likelihood, impact, framework, status
+  FROM risks
+ ORDER BY likelihood * impact DESC, id DESC;
+
+-- Incidents whose DORA deadline is within 4 hours
+SELECT id, title, severity, dora_deadline
+  FROM incidents
+ WHERE status = 'open'
+   AND dora_deadline BETWEEN datetime('now') AND datetime('now', '+4 hours');
+
+-- Most recent 200 audit entries (admin view)
+SELECT id, user_id, action, details, ip_address, timestamp, row_hash
+  FROM audit_log
+ ORDER BY id DESC
+ LIMIT 200;
+
+-- Walk the chain to verify integrity (server-side; see audit.verify_chain)
+SELECT id, user_id, action, details, ip_address, prev_hash, row_hash
+  FROM audit_log
+ ORDER BY id ASC;
+
+-- Dashboard KPIs
+SELECT
+  (SELECT COUNT(*) FROM users)                              AS users,
+  (SELECT COUNT(*) FROM incidents WHERE status = 'open')    AS open_incidents,
+  (SELECT COUNT(*) FROM risks)                              AS risks,
+  (SELECT COUNT(*) FROM audit_log)                          AS audit_entries;
+
+-- Risk bucket distribution
+SELECT CASE
+         WHEN likelihood * impact >= 20 THEN 'Critical'
+         WHEN likelihood * impact >= 12 THEN 'High'
+         WHEN likelihood * impact >= 6  THEN 'Medium'
+         ELSE 'Low'
+       END AS bucket, COUNT(*) AS count
+  FROM risks
+ GROUP BY bucket;
+```
+
+---
+
+## 7. Migration workflow
+
+Migrations are plain SQL files under `services/web/migrations/`, applied
+in **lexicographic order** exactly once per database. The runner:
+
+1. Creates `schema_migrations` if it does not exist.
+2. Loads applied names into a set.
+3. For each `*.sql` file, if its name is not in the set, executes it inside
+   a transaction and inserts the name into `schema_migrations`.
+
+CLI:
+
+```bash
+python -m services.web.migrate              # apply pending
+python -m services.web.migrate --status     # show applied vs pending
+python -m services.web.migrate --bootstrap  # apply + create superadmin
+python -m services.web.migrate --verify     # re-walk audit hash chain
+```
+
+Naming convention: `NNNN_<short_topic>.sql` — e.g. `0003_documents.sql`.
+
+Backward-incompatible changes require a new migration file (never edit a
+shipped one) so existing databases converge to the same schema deterministically.

--- a/scripts/install-web.ps1
+++ b/scripts/install-web.ps1
@@ -1,0 +1,177 @@
+<#
+.SYNOPSIS
+    HybridSOC Web — Windows install & bootstrap script (PowerShell).
+
+.DESCRIPTION
+    Sets up the Flask backend, the React/Vite frontend (preferring Bun,
+    falling back to Node.js + npm), runs SQLite migrations, and creates
+    the bootstrap superadmin. Targets Windows 10/11 with Python 3.10+.
+
+.PARAMETER NoFrontend
+    Skip the JS install/build entirely.
+
+.PARAMETER Dev
+    Install JS dependencies but skip the production build (useful when
+    you intend to run `bun run dev` / `npm run dev`).
+
+.EXAMPLE
+    PS> .\scripts\install-web.ps1
+    PS> .\scripts\install-web.ps1 -Dev
+    PS> .\scripts\install-web.ps1 -NoFrontend
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$NoFrontend,
+    [switch]$Dev
+)
+
+$ErrorActionPreference = 'Stop'
+$PyRequiredMinor       = 10
+$NodeRequiredMajor     = 20
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$WebDir   = Join-Path $RepoRoot 'services\web'
+$FrontDir = Join-Path $WebDir   'frontend'
+
+function Log  { param([string]$m) Write-Host "[install] $m" -ForegroundColor Cyan }
+function Warn { param([string]$m) Write-Host "[warn] $m"    -ForegroundColor Yellow }
+function Fail { param([string]$m) Write-Host "[fail] $m"    -ForegroundColor Red; exit 1 }
+
+# ── Python ────────────────────────────────────────────────────────────────
+function Test-Python {
+    $py = Get-Command python -ErrorAction SilentlyContinue
+    if (-not $py) { Fail "python not found (need >= 3.$PyRequiredMinor). Install from https://www.python.org/downloads/ or 'winget install Python.Python.3.12'." }
+    $minor = & python -c "import sys; print(sys.version_info.minor)"
+    if ([int]$minor -lt $PyRequiredMinor) { Fail "python >= 3.$PyRequiredMinor required (have 3.$minor)" }
+    Log "Python $(& python --version) detected"
+}
+
+function Initialize-Python {
+    Test-Python
+    Log "Creating Python virtualenv at $WebDir\.venv"
+    & python -m venv (Join-Path $WebDir '.venv')
+    $pip = Join-Path $WebDir '.venv\Scripts\pip.exe'
+    & $pip install --upgrade pip wheel | Out-Null
+    Log "Installing Python dependencies"
+    & $pip install -r (Join-Path $WebDir 'requirements.txt')
+}
+
+# ── .env ──────────────────────────────────────────────────────────────────
+function Initialize-Env {
+    $envFile = Join-Path $WebDir '.env'
+    if (Test-Path $envFile) { Log ".env already exists — leaving it untouched"; return }
+    Copy-Item (Join-Path $WebDir '.env.example') $envFile
+    $secret = & python -c "import secrets; print(secrets.token_urlsafe(48))"
+    $pepper = & python -c "import secrets; print(secrets.token_urlsafe(32))"
+    (Get-Content $envFile) `
+        -replace '^FLASK_SECRET_KEY=.*', "FLASK_SECRET_KEY=$secret" `
+        -replace '^HYBRIDSOC_PEPPER=.*', "HYBRIDSOC_PEPPER=$pepper" `
+        | Set-Content -Encoding UTF8 $envFile
+    Log "Wrote $envFile (review SMTP / Turnstile / bootstrap values)"
+}
+
+# ── Migrations + bootstrap ────────────────────────────────────────────────
+function Invoke-Migrations {
+    Log "Running SQLite migrations and bootstrapping superadmin"
+    Push-Location $RepoRoot
+    try {
+        # Load .env into the current process scope
+        $envPath = Join-Path $WebDir '.env'
+        if (Test-Path $envPath) {
+            Get-Content $envPath | ForEach-Object {
+                if ($_ -match '^\s*#') { return }
+                if ($_ -match '^\s*([^=\s]+)\s*=\s*(.*)\s*$') {
+                    [Environment]::SetEnvironmentVariable($matches[1], $matches[2], 'Process')
+                }
+            }
+        }
+        $py = Join-Path $WebDir '.venv\Scripts\python.exe'
+        & $py -m services.web.migrate --bootstrap
+    } finally { Pop-Location }
+}
+
+# ── Bun (preferred) / Node.js fallback ───────────────────────────────────
+function Install-Bun {
+    Log "Installing Bun (https://bun.sh)…"
+    # Official Windows installer
+    powershell -NoProfile -ExecutionPolicy Bypass -Command "irm bun.sh/install.ps1 | iex"
+    $bunDir = Join-Path $env:USERPROFILE '.bun\bin'
+    if (Test-Path (Join-Path $bunDir 'bun.exe')) {
+        $env:PATH = "$bunDir;$env:PATH"
+        return $true
+    }
+    return $false
+}
+
+function Test-Node {
+    $node = Get-Command node -ErrorAction SilentlyContinue
+    if (-not $node) { return $false }
+    $major = (& node -v).TrimStart('v').Split('.')[0]
+    return ([int]$major -ge $NodeRequiredMajor)
+}
+
+function Resolve-JsRunner {
+    if (Get-Command bun -ErrorAction SilentlyContinue) {
+        Log "Bun $(& bun --version) detected"
+        return 'bun'
+    }
+    if (Install-Bun) {
+        Log "Bun $(& bun --version) installed"
+        return 'bun'
+    }
+    Warn "Bun unavailable — checking Node.js"
+    if (Test-Node) {
+        Log "Node.js $(& node -v) detected"
+        return 'npm'
+    }
+    Fail "Need Bun (https://bun.sh) or Node.js >= $NodeRequiredMajor.x. Install one and re-run, e.g. 'winget install OpenJS.NodeJS.LTS' or 'winget install Oven-sh.Bun'."
+}
+
+# ── Frontend ──────────────────────────────────────────────────────────────
+function Build-Frontend {
+    $runner = Resolve-JsRunner
+    Log "Installing frontend dependencies (using $runner)"
+    Push-Location $FrontDir
+    try {
+        if ($runner -eq 'bun') {
+            & bun install
+            if ($Dev) { Log "Skipping build (-Dev). Run 'bun run dev' in $FrontDir to start Vite." }
+            else      { Log "Building frontend (bun run build)"; & bun run build }
+        } else {
+            & npm install --no-audit --no-fund
+            if ($Dev) { Log "Skipping build (-Dev). Run 'npm run dev' in $FrontDir to start Vite." }
+            else      { Log "Building frontend (npm run build)"; & npm run build }
+        }
+    } finally { Pop-Location }
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────
+Log "HybridSOC Web installer (PowerShell) — repo: $RepoRoot"
+Initialize-Python
+Initialize-Env
+Invoke-Migrations
+if (-not $NoFrontend) { Build-Frontend } else { Warn "Skipping frontend (-NoFrontend)" }
+
+@"
+
+────────────────────────────────────────────────────────────────────
+HybridSOC Web is ready.
+
+Start the backend (serves the built frontend on the same port):
+  cd $WebDir
+  .\.venv\Scripts\Activate.ps1
+  Get-Content .env | ForEach-Object { if (`$_ -match '^([^=]+)=(.*)') { [Environment]::SetEnvironmentVariable(`$matches[1], `$matches[2], 'Process') } }
+  python -m services.web.app          # http://localhost:5000
+
+For frontend hot-reload during development (separate terminal):
+  cd $FrontDir
+  bun run dev                         # http://localhost:5173 (proxies /api -> :5000)
+  # or, if you prefer npm:
+  # npm run dev
+
+Default bootstrap login (change the password immediately):
+  email:    `$BOOTSTRAP_EMAIL    (see .env)
+  password: `$BOOTSTRAP_PASSWORD (see .env)
+────────────────────────────────────────────────────────────────────
+"@

--- a/scripts/install-web.sh
+++ b/scripts/install-web.sh
@@ -42,14 +42,33 @@ need_python() {
   [[ "$minor" -ge "$PY_REQUIRED_MINOR" ]] || fail "python3 >= 3.${PY_REQUIRED_MINOR} required (have 3.${minor})"
 }
 
-# ── Node.js (install if missing on Linux via NodeSource) ──────────────────
+# ── Bun (preferred) — falls back to Node.js + npm if unavailable ─────────
+JS_RUNNER=""
+
+ensure_bun() {
+  if command -v bun >/dev/null; then
+    log "Bun $(bun --version) detected"
+    JS_RUNNER="bun"; return 0
+  fi
+  log "Bun not found — installing official build (https://bun.sh)…"
+  if curl -fsSL https://bun.sh/install | bash; then
+    # Bun installs to ~/.bun/bin
+    export PATH="$HOME/.bun/bin:$PATH"
+    if command -v bun >/dev/null; then
+      log "Bun $(bun --version) installed"
+      JS_RUNNER="bun"; return 0
+    fi
+  fi
+  warn "Bun install failed — falling back to npm"
+}
+
 ensure_node() {
   if command -v node >/dev/null; then
     local ver
     ver="$(node -v | sed 's/v//' | cut -d. -f1)"
     if [[ "$ver" -ge "$NODE_REQUIRED_MAJOR" ]]; then
       log "Node.js $(node -v) detected"
-      return 0
+      JS_RUNNER="npm"; return 0
     fi
     warn "Node.js $(node -v) detected; need >= ${NODE_REQUIRED_MAJOR}.x"
   else
@@ -66,8 +85,14 @@ ensure_node() {
     curl -fsSL "https://deb.nodesource.com/setup_${NODE_REQUIRED_MAJOR}.x" | $SUDO bash -
     $SUDO apt-get install -y nodejs
   else
-    fail "Please install Node.js >= ${NODE_REQUIRED_MAJOR}.x (https://nodejs.org/) and re-run."
+    fail "Please install Bun (https://bun.sh) or Node.js >= ${NODE_REQUIRED_MAJOR}.x and re-run."
   fi
+  JS_RUNNER="npm"
+}
+
+ensure_js_runner() {
+  ensure_bun
+  [[ -z "$JS_RUNNER" ]] && ensure_node
 }
 
 # ── Python venv + deps ────────────────────────────────────────────────────
@@ -109,14 +134,24 @@ run_migrations() {
 
 # ── Frontend ──────────────────────────────────────────────────────────────
 build_frontend() {
-  ensure_node
-  log "Installing frontend dependencies"
-  ( cd "$FRONT_DIR" && npm install --no-audit --no-fund )
-  if [[ "$DEV_MODE" -eq 1 ]]; then
-    log "Skipping production build (--dev). Run 'npm run dev' inside ${FRONT_DIR} to start Vite."
+  ensure_js_runner
+  log "Installing frontend dependencies (using ${JS_RUNNER})"
+  if [[ "$JS_RUNNER" == "bun" ]]; then
+    ( cd "$FRONT_DIR" && bun install )
+    if [[ "$DEV_MODE" -eq 1 ]]; then
+      log "Skipping production build (--dev). Run 'bun run dev' inside ${FRONT_DIR} to start Vite."
+    else
+      log "Building frontend (bun run build)"
+      ( cd "$FRONT_DIR" && bun run build )
+    fi
   else
-    log "Building frontend (vite build)"
-    ( cd "$FRONT_DIR" && npm run build )
+    ( cd "$FRONT_DIR" && npm install --no-audit --no-fund )
+    if [[ "$DEV_MODE" -eq 1 ]]; then
+      log "Skipping production build (--dev). Run 'npm run dev' inside ${FRONT_DIR} to start Vite."
+    else
+      log "Building frontend (vite build)"
+      ( cd "$FRONT_DIR" && npm run build )
+    fi
   fi
 }
 
@@ -144,7 +179,9 @@ Start the backend (serves the built frontend on the same port):
 
 For frontend hot-reload during development (separate terminal):
   cd ${FRONT_DIR}
-  npm run dev                         # http://localhost:5173 (proxies /api → :5000)
+  bun run dev                         # http://localhost:5173 (proxies /api → :5000)
+  # or, if you prefer npm:
+  # npm run dev
 
 Default bootstrap login (change the password immediately):
   email:    \$BOOTSTRAP_EMAIL    (see .env)

--- a/services/web/README.md
+++ b/services/web/README.md
@@ -28,15 +28,42 @@ services/web/
 
 ## One-shot install
 
+### Linux / macOS (bash)
+
 ```bash
 bash scripts/install-web.sh           # backend + frontend build
 bash scripts/install-web.sh --dev     # backend + frontend deps, no build
 bash scripts/install-web.sh --no-frontend
 ```
 
-The script will install Node.js 20.x via NodeSource on Debian/Ubuntu if it is missing.
+The script prefers **Bun** for the JS toolchain and installs it from
+`https://bun.sh/install` if it is missing. If Bun cannot be installed, it
+falls back to Node.js 20.x (installed via NodeSource on Debian/Ubuntu).
+
+### Windows (PowerShell)
+
+```powershell
+# From the repo root, in a PowerShell window
+.\scripts\install-web.ps1                  # backend + frontend build
+.\scripts\install-web.ps1 -Dev             # backend + frontend deps, no build
+.\scripts\install-web.ps1 -NoFrontend
+```
+
+If you hit an execution-policy error, allow scripts for the current process:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+```
+
+The PowerShell installer prefers Bun (installed via `irm bun.sh/install.ps1 | iex`)
+and falls back to Node.js 20.x. Pre-install Python 3.10+ from python.org
+or `winget install Python.Python.3.12` before running it.
 
 ## Manual setup
+
+### Backend (cross-platform)
+
+Linux / macOS:
 
 ```bash
 cd services/web
@@ -47,11 +74,44 @@ python -m services.web.migrate --bootstrap
 python -m services.web.app             # http://localhost:5000
 ```
 
+Windows PowerShell:
+
+```powershell
+cd services\web
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+Copy-Item .env.example .env             # edit values in your editor
+Get-Content .env | ForEach-Object { if ($_ -match '^([^=]+)=(.*)') { [Environment]::SetEnvironmentVariable($matches[1], $matches[2], 'Process') } }
+python -m services.web.migrate --bootstrap
+python -m services.web.app              # http://localhost:5000
+```
+
+For production (gunicorn, Linux/macOS only — on Windows use `waitress` or run
+behind IIS):
+
+```bash
+gunicorn -w 4 -b 0.0.0.0:5000 'services.web.app:create_app()'
+```
+
+### Frontend — Bun (recommended)
+
+```bash
+cd services/web/frontend
+bun install
+bun run dev                            # http://localhost:5173 (proxies /api → :5000)
+bun run build                          # writes ./dist served by Flask
+```
+
+PowerShell uses identical commands (`bun install`, `bun run dev`, `bun run build`).
+
+### Frontend — npm fallback
+
 ```bash
 cd services/web/frontend
 npm install
-npm run dev                            # http://localhost:5173 (proxies /api → :5000)
-npm run build                          # writes ./dist served by Flask in production
+npm run dev
+npm run build
 ```
 
 ## SQLite update service


### PR DESCRIPTION
## Summary

Three things in one PR:

1. **JS toolchain → Bun.** `scripts/install-web.sh` now prefers Bun (installed from `bun.sh/install` if missing) and falls back to Node.js 20.x + npm. The frontend build branches on a single `JS_RUNNER` variable resolved by `ensure_js_runner()`.
2. **Windows support.** New `scripts/install-web.ps1` provides the same Python venv / `.env` seeding / migration / superadmin-bootstrap pipeline on Windows PowerShell. It installs Bun via `irm bun.sh/install.ps1 | iex` (with Node.js fallback) and exposes `-Dev` / `-NoFrontend` flags matching the bash script.
3. **Database schema doc.** New `docs/database-schema.md` — companion to `docs/system-design.md`. Covers the `WAL` / `synchronous=NORMAL` / `foreign_keys=ON` PRAGMA settings, per-table DDL (tenants, users, sessions, email_otp, audit_log, risks, incidents, vendors, schema_migrations) with constraints and FK behaviour, indexes, retention policies, the SHA-256 hash-chain construction in `audit.py`, and the reference queries used by the dashboard / risk / GRC / audit blueprints.

Both READMEs (`README.md`, `services/web/README.md`) now show install + run instructions side-by-side for Linux/macOS bash and Windows PowerShell, and document `bun` and `npm` commands.

## Test plan

- [ ] `bash -n scripts/install-web.sh` passes (verified)
- [ ] `bash scripts/install-web.sh --dev` succeeds on a clean Debian/Ubuntu box, picking up Bun
- [ ] `bash scripts/install-web.sh --dev` succeeds on a box without Bun (falls back to Node.js 20.x via NodeSource)
- [ ] `.\scripts\install-web.ps1 -Dev` succeeds on Windows 10/11 with Python 3.10+ pre-installed
- [ ] `bun run dev` and `npm run dev` both serve `http://localhost:5173` and proxy `/api` to `:5000`
- [ ] `python -m services.web.migrate --status` lists `0001_initial.sql`, `0002_grc.sql`
- [ ] All entries in `docs/database-schema.md` ER diagram and DDL sections match `services/web/migrations/*.sql`

---
_Generated by [Claude Code](https://claude.ai/code/session_017yh2aHGgJegs288NP9G7Ux)_